### PR TITLE
Update dependencies, crate now compiles on rust 1.41.0

### DIFF
--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-minidom = "0.5.0"
-quick-xml = "0.7.3"
+minidom = "^0.6.0"
+quick-xml = "^0.9.0"
 log = "0.4.8"
 failure = "0.1.1"
 serde = "^1.0.89"


### PR DESCRIPTION
The crate did not compile anymore, due to a compile error with the encoding_rs crate.

See probe-rs/target-gen#9 

This PR updates some dependencies, and now it compiles again.