### PR TITLE
Merge parent processor attributes

### DIFF
--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -144,6 +144,15 @@ struct ProcessorBuilder {
 }
 
 impl ProcessorBuilder {
+    fn merge(self, other: &Self) -> Self {
+        Self {
+            core: self.core.or(other.core.clone()),
+            units: self.units.or(other.units),
+            name: self.name.or(other.name.clone()),
+            fpu: self.fpu.or(other.fpu.clone()),
+            mpu: self.mpu.or(other.mpu.clone()),
+        }
+    }
     fn build(self, debugs: &Vec<Debug>) -> Result<Vec<Processor>, Error> {
         let units = self.units.unwrap_or(1);
         let name = self.name.clone();
@@ -219,11 +228,17 @@ impl FromElem for ProcessorBuilder {
 struct ProcessorsBuilder(Vec<ProcessorBuilder>);
 
 impl ProcessorsBuilder {
-    fn merge(mut self, parent: &Option<Self>) -> Self {
+    fn merge(mut self, parent: &Option<Self>) -> Result<Self, Error> {
         if let Some(parent) = parent {
-            self.0.extend(parent.0.iter().map(|v| v.clone()))
+            if let [parent] = &parent.0[..] {
+                self.0 = self.0.into_iter().map(|x| x.merge(parent)).collect();
+            } else {
+                Err(format_err!(
+                    "Support for two parent processors not implemented!"
+                ))?;
+            }
         }
-        self
+        Ok(self)
     }
 
     fn merge_into(&mut self, other: Self) {
@@ -569,7 +584,7 @@ impl<'dom> DeviceBuilder<'dom> {
             algorithms: self.algorithms,
             memories: merge_memories(self.memories, &parent.memories),
             processor: match self.processor {
-                Some(old_proc) => Some(old_proc.merge(&parent.processor)),
+                Some(old_proc) => Some(old_proc.merge(&parent.processor)?),
                 None => parent.processor.clone(),
             },
             debugs: self.debugs.merge(&parent.debugs),


### PR DESCRIPTION
According to https://www.keil.com/pack/doc/CMSIS/Pack/html/pdsc_family_pg.html#element_processor, the attributes of the processor in e.g. the family are used for processors in e.g. the device, if they're not set there.

In pack files like the ones for the XMC1000 series this is used (abbreviated):
```
    <family Dfamily="XMC1000" Dvendor="Infineon:7">
      <processor Dcore="Cortex-M0" DcoreVersion="r0p0" Dfpu="NO_FPU" Dmpu="NO_MPU" 
      <subFamily DsubFamily="XMC1100 Series">
      <device Dname="XMC1100-Q024x0008">
        <processor Dclock="32000000"/>
```

and for other pack files like: `Keil.STM32F1xx_DFP.2.3.0.pack`.

With this PR attributes of the parent processor element are merged into the device processor element if one already exists, previously two processors would have been created, which is somewhat nonsensical.

If there are two processor instances in the family or subFamily as well as in the device, they probably need to be matched using Pname & Punits but I'm not sure. Thus this gives an error.